### PR TITLE
feat(deps): upgrade iOSDFULibrary

### DIFF
--- a/ios/RNNordicDfu.h
+++ b/ios/RNNordicDfu.h
@@ -9,8 +9,8 @@
 @property (strong, nonatomic) RCTPromiseResolveBlock resolve;
 @property (strong, nonatomic) RCTPromiseRejectBlock reject;
 
-+ (void)setCentralManagerGetter:(CBCentralManager * (^)())getter;
-+ (void)setOnDFUComplete:(void (^)())onComplete;
-+ (void)setOnDFUError:(void (^)())onError;
++ (void)setCentralManagerGetter:(CBCentralManager * (^)(void))getter;
++ (void)setOnDFUComplete:(void (^)(void))onComplete;
++ (void)setOnDFUError:(void (^)(void))onError;
 
 @end

--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -238,10 +238,10 @@ RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
             initiator.progressDelegate = self;
             initiator.alternativeAdvertisingNameEnabled = alternativeAdvertisingNameEnabled;
 
-            // Change for iOS 13
+            // Change for iOS 13+
             initiator.packetReceiptNotificationParameter = 1; //Rate limit the DFU using PRN.
-            [NSThread sleepForTimeInterval: 2]; //Work around for being stuck in iOS 13
-            // End change for iOS 13
+            [NSThread sleepForTimeInterval: 5]; //Work around for being stuck in iOS 13+
+            // End change for iOS 13+
 
             (void)[initiator startWithTargetWithIdentifier:peripheral.identifier];
         } @catch (NSException * e) {

--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -2,9 +2,9 @@
 #import <CoreBluetooth/CoreBluetooth.h>
 @import iOSDFULibrary;
 
-static CBCentralManager * (^getCentralManager)();
-static void (^onDFUComplete)();
-static void (^onDFUError)();
+static CBCentralManager * (^getCentralManager)(void);
+static void (^onDFUComplete)(void);
+static void (^onDFUError)(void);
 
 @implementation RNNordicDfu
 
@@ -253,17 +253,17 @@ RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
   }
 }
 
-+ (void)setCentralManagerGetter:(CBCentralManager * (^)())getter
++ (void)setCentralManagerGetter:(CBCentralManager * (^)(void))getter
 {
   getCentralManager = getter;
 }
 
-+ (void)setOnDFUComplete:(void (^)())onComplete
++ (void)setOnDFUComplete:(void (^)(void))onComplete
 {
   onDFUComplete = onComplete;
 }
 
-+ (void)setOnDFUError:(void (^)())onError
++ (void)setOnDFUError:(void (^)(void))onError
 {
   onDFUError = onError;
 }

--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -208,7 +208,7 @@ RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
       NSUUID * uuid = [[NSUUID alloc] initWithUUIDString:deviceAddress];
 
       // Change for iOS 13
-      [NSThread sleepForTimeInterval: 1]; //Work around for not finding the peripheral in iOS 13
+      [NSThread sleepForTimeInterval: 3]; //Work around for not finding the peripheral in iOS 13
       // End change for iOS 13
       
       NSArray<CBPeripheral *> * peripherals = [centralManager retrievePeripheralsWithIdentifiers:@[uuid]];

--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -220,24 +220,29 @@ RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
 
         NSURL * url = [NSURL URLWithString:filePath];
 
-        DFUFirmware * firmware = [[DFUFirmware alloc] initWithUrlToZipFile:url];
+        @try {
+          DFUFirmware * firmware = [[DFUFirmware alloc] initWithUrlToZipFile:url];
 
-        DFUServiceInitiator * initiator = [[[DFUServiceInitiator alloc]
-                                            initWithCentralManager:centralManager
-                                            target:peripheral]
-                                           withFirmware:firmware];
+          DFUServiceInitiator * initiator = [[[DFUServiceInitiator alloc]
+                                              initWithCentralManager:centralManager
+                                              target:peripheral]
+                                            withFirmware:firmware];
 
-        initiator.logger = self;
-        initiator.delegate = self;
-        initiator.progressDelegate = self;
-        initiator.alternativeAdvertisingNameEnabled = alternativeAdvertisingNameEnabled;
+          initiator.logger = self;
+          initiator.delegate = self;
+          initiator.progressDelegate = self;
+          initiator.alternativeAdvertisingNameEnabled = alternativeAdvertisingNameEnabled;
 
-        // Change for iOS 13
-        initiator.packetReceiptNotificationParameter = 1; //Rate limit the DFU using PRN.
-        [NSThread sleepForTimeInterval: 2]; //Work around for being stuck in iOS 13
-        // End change for iOS 13
+          // Change for iOS 13
+          initiator.packetReceiptNotificationParameter = 1; //Rate limit the DFU using PRN.
+          [NSThread sleepForTimeInterval: 2]; //Work around for being stuck in iOS 13
+          // End change for iOS 13
 
-        DFUServiceController * controller = [initiator start];
+          DFUServiceController * controller = [initiator start];
+        } @catch (NSException * e) {
+          NSString *errorMessage = [NSString stringWithFormat:@"Unable to start DFU: %@, reason: %@", e.name, e.reason];
+          reject(@"unable_to_start_dfu", errorMessage, nil);
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nordic-dfu",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
   "url": "https://github.com/Pilloxa/react-native-nordic-dfu",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nordic-dfu",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
   "url": "https://github.com/Pilloxa/react-native-nordic-dfu",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nordic-dfu",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
   "url": "https://github.com/Pilloxa/react-native-nordic-dfu",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nordic-dfu",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
   "url": "https://github.com/Pilloxa/react-native-nordic-dfu",

--- a/react-native-nordic-dfu.podspec
+++ b/react-native-nordic-dfu.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'iOSDFULibrary', '~> 4.12.0'
+  s.dependency 'iOSDFULibrary', '~> 4.13.0'
 end


### PR DESCRIPTION
The project is a React Native library. It is composed of an index, a packages.json config file and two native projects for Android and iOS 

The iOS part is composed of a podspec file that lists the iOS native dependencies, some code in Objective-C and a project configuration file. 

## Summary 
- upgrade `iOSDFULibrary` to `4.13.0`. Migration guide: https://github.com/NordicSemiconductor/IOS-DFU-Library/releases/tag/4.13.0

## Details
- Update the deprecated functions from `iOSDFULibrary`
- Update the workaround by incrementing `sleepForTimeInterval` to 3 and 5 seconds
- Implement a queue to init the `DFUServiceInitiator`

